### PR TITLE
MLflow

### DIFF
--- a/experiments/invariant-risk-minimization/wildcam/README.md
+++ b/experiments/invariant-risk-minimization/wildcam/README.md
@@ -66,7 +66,7 @@ export PATH=/usr/local/cuda-10.0/bin${PATH:+:${PATH}}
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-10.0/lib64
 nvcc --version
 conda install pytorch torchvision cudatoolkit=10.0 -c pytorch
-conda install -c conda-forge matplotlib
+conda install -c conda-forge matplotlib mlflow
 conda install nb_conda
 ```
 

--- a/experiments/invariant-risk-minimization/wildcam/env.yaml
+++ b/experiments/invariant-risk-minimization/wildcam/env.yaml
@@ -5,32 +5,52 @@ channels:
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
+  - alembic=1.4.2=pyh9f0ad1d_0
+  - appdirs=1.4.3=py_1
+  - asn1crypto=1.3.0=py37_0
   - attrs=19.3.0=py_0
   - backcall=0.1.0=py37_0
+  - backports=1.0=py_2
   - blas=1.0=mkl
   - bleach=3.1.0=py37_0
-  - ca-certificates=2020.1.1=0
-  - certifi=2019.11.28=py37_0
+  - ca-certificates=2019.11.28=hecc5488_0
+  - certifi=2019.11.28=py37hc8dfbb8_1
+  - cffi=1.14.0=py37hd463f26_0
+  - chardet=3.0.4=py37hc8dfbb8_1006
+  - click=7.1.1=pyh8c360ce_0
+  - cloudpickle=1.3.0=py_0
+  - configparser=3.7.3=py37hc8dfbb8_2
+  - cryptography=2.8=py37hb09aad4_2
   - cudatoolkit=10.0.130=0
   - cycler=0.10.0=py_2
+  - databricks-cli=0.9.1=py_0
   - dbus=1.13.6=he372182_0
   - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
+  - docker-py=4.2.0=py37_0
+  - docker-pycreds=0.4.0=py_0
   - entrypoints=0.3=py37_0
   - expat=2.2.9=he1b5a44_2
+  - flask=1.1.1=py_1
   - fontconfig=2.13.1=he4413a7_1000
   - freetype=2.9.1=h8a8886c_1
   - gettext=0.19.8.1=hc5be6a0_1002
+  - gitdb=4.0.2=py_0
+  - gitpython=3.1.0=py_0
   - glib=2.58.3=py37he00f558_1003
   - gmp=6.1.2=h6c8ec71_1
+  - gorilla=0.3.0=py_0
   - gst-plugins-base=1.14.5=h0935bb2_2
   - gstreamer=1.14.5=h36ae1b5_2
+  - gunicorn=20.0.4=py37hc8dfbb8_1
   - icu=58.2=hf484d3e_1000
+  - idna=2.9=py_1
   - importlib_metadata=1.5.0=py37_0
   - intel-openmp=2020.0=166
   - ipykernel=5.1.4=py37h39e3cac_0
   - ipython=7.13.0=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py37_0
+  - itsdangerous=1.1.0=py_0
   - jedi=0.16.0=py37_0
   - jinja2=2.11.1=py_0
   - jpeg=9b=h024ee3a_2
@@ -45,12 +65,14 @@ dependencies:
   - libgfortran-ng=7.3.0=hdf63c60_0
   - libiconv=1.15=h516909a_1006
   - libpng=1.6.37=hbc83047_0
+  - libprotobuf=3.11.4=h8b12597_0
   - libsodium=1.0.16=h1bed415_0
   - libstdcxx-ng=9.1.0=hdf63c60_0
   - libtiff=4.1.0=h2733197_0
   - libuuid=2.32.1=h14c3975_1000
   - libxcb=1.13=h14c3975_1002
   - libxml2=2.9.9=hea5a465_1
+  - mako=1.1.0=py_0
   - markupsafe=1.1.1=py37h7b6447c_0
   - matplotlib=3.1.3=py37_0
   - matplotlib-base=3.1.3=py37hef1b27d_0
@@ -59,6 +81,7 @@ dependencies:
   - mkl-service=2.3.0=py37he904b0f_0
   - mkl_fft=1.0.15=py37ha843d7b_0
   - mkl_random=1.1.0=py37hd6b4f25_0
+  - mlflow=1.7.1=py37hc8dfbb8_0
   - nb_conda=2.2.1=py37_0
   - nb_conda_kernels=2.2.2=py37_0
   - nbconvert=5.6.1=py37_0
@@ -69,7 +92,9 @@ dependencies:
   - numpy=1.18.1=py37h4f9e942_0
   - numpy-base=1.18.1=py37hde5b4d6_1
   - olefile=0.46=py37_0
-  - openssl=1.1.1e=h7b6447c_0
+  - openssl=1.1.1e=h516909a_0
+  - packaging=20.1=py_0
+  - pandas=1.0.3=py37h0da4684_0
   - pandoc=2.2.3.2=0
   - pandocfilters=1.4.2=py37_1
   - parso=0.6.2=py_0
@@ -79,37 +104,56 @@ dependencies:
   - pillow=7.0.0=py37hb39fc2d_0
   - pip=20.0.2=py37_1
   - prometheus_client=0.7.1=py_0
+  - prometheus_flask_exporter=0.13.0=py_0
   - prompt_toolkit=3.0.3=py_0
+  - protobuf=3.11.4=py37he1b5a44_0
   - pthread-stubs=0.4=h14c3975_1001
   - ptyprocess=0.6.0=py37_0
+  - pycparser=2.20=py_0
   - pygments=2.6.1=py_0
+  - pyopenssl=19.1.0=py_1
   - pyparsing=2.4.6=py_0
   - pyqt=5.9.2=py37hcca6a23_4
   - pyrsistent=0.15.7=py37h7b6447c_0
+  - pysocks=1.7.1=py37hc8dfbb8_1
   - python=3.7.6=h0371630_2
   - python-dateutil=2.8.1=py_0
+  - python-editor=1.0.4=py_0
   - python_abi=3.7=1_cp37m
   - pytorch=1.4.0=py3.7_cuda10.0.130_cudnn7.6.3_0
+  - pytz=2019.3=py_0
+  - pyyaml=5.3.1=py37h8f50634_0
   - pyzmq=18.1.1=py37he6710b0_0
   - qt=5.9.7=h5867ecd_1
+  - querystring_parser=1.2.4=py_0
   - readline=7.0=h7b6447c_5
+  - requests=2.23.0=pyh8c360ce_2
   - send2trash=1.5.0=py37_0
   - setuptools=46.0.0=py37_0
+  - simplejson=3.17.0=py37h516909a_0
   - sip=4.19.8=py37hf484d3e_0
   - six=1.14.0=py37_0
+  - smmap=3.0.1=py_0
+  - sqlalchemy=1.3.13=py37h516909a_0
   - sqlite=3.31.1=h7b6447c_0
+  - sqlparse=0.3.1=py_0
+  - tabulate=0.8.6=py_0
   - terminado=0.8.3=py37_0
   - testpath=0.4.4=py_0
   - tk=8.6.8=hbc83047_0
   - torchvision=0.5.0=py37_cu100
   - tornado=6.0.4=py37h7b6447c_1
   - traitlets=4.3.3=py37_0
+  - urllib3=1.25.7=py37hc8dfbb8_1
   - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py37_1
+  - websocket-client=0.57.0=py37hc8dfbb8_1
+  - werkzeug=1.0.0=py_0
   - wheel=0.34.2=py37_0
   - xorg-libxau=1.0.9=h14c3975_0
   - xorg-libxdmcp=1.1.3=h516909a_0
   - xz=5.2.4=h14c3975_4
+  - yaml=0.2.2=h516909a_1
   - zeromq=4.3.1=he6710b0_3
   - zipp=2.2.0=py_0
   - zlib=1.2.11=h7b6447c_3

--- a/experiments/invariant-risk-minimization/wildcam/main.py
+++ b/experiments/invariant-risk-minimization/wildcam/main.py
@@ -88,7 +88,7 @@ train_process = Train(envs, x_test, y_test, net, handler, args)
 
 
 start = datetime.now()
-with mlflow.start_run(nested=True):
+with mlflow.start_run():
     
     mlflow.log_params({
         'steps': args['steps'],

--- a/experiments/invariant-risk-minimization/wildcam/main.py
+++ b/experiments/invariant-risk-minimization/wildcam/main.py
@@ -3,6 +3,7 @@ import torch
 import matplotlib.pyplot as plt
 import pickle
 import random
+import mlflow
 
 from dataset import get_dataset, get_handler
 from models import get_net
@@ -10,103 +11,129 @@ from train import Train
 from torchvision import transforms
 from datetime import datetime
 
-if __name__ == "__main__":
-    
-    seed = 123
-    dataset_name = 'WILDCAM'
-    dataset_path = '/datapool/wildcam/wildcam_subset_sample'
-    
-    args_pool = {
-        'WILDCAM': {
-            'n_restarts': 1,
-            'steps': 1,
-            'n_classes': 2,
-            'fc_only': True,
-            'model_path': "./models/",
-            'transform': {
-                'train': transforms.Compose([
-                                             transforms.CenterCrop(224),
-                                             transforms.ToTensor(),
-                                             transforms.Normalize([0.485, 0.456, 0.406],[0.229, 0.224, 0.225])]),
-                'test': transforms.Compose([
-                                            transforms.CenterCrop(224),
-                                            transforms.ToTensor(),
-                                            transforms.Normalize([0.485, 0.456, 0.406],[0.229, 0.224, 0.225])])
-            },
-            'loader_tr_args': {
-                'batch_size': 100, 
-                'num_workers': 1
-            },
-            'loader_te_args': {
-                'batch_size': 100, 
-                'num_workers': 1
-            },
-            'loader_sample_args': {
-                'batch_size': 100, 
-                'num_workers': 1
-            },
-            'optimizer_args': {
-                'lr': 0.001,
-                'l2_regularizer_weight': 0.001,
-                'penalty_anneal_iters': 40, # make this 0 for ERM
-                'penalty_weight': 10000.0 # make this 0 for ERM
-            }
+seed = 123
+dataset_name = 'WILDCAM'
+dataset_path = '/datapool/wildcam/wildcam_subset_sample'
+
+args_pool = {
+    'WILDCAM': {
+        'n_restarts': 3,
+        'steps': 5,
+        'n_classes': 2,
+        'fc_only': True,
+        'model_path': "./models/",
+        'transform': {
+            'train': transforms.Compose([
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize([0.485, 0.456, 0.406],[0.229, 0.224, 0.225])]),
+            'test': transforms.Compose([
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize([0.485, 0.456, 0.406],[0.229, 0.224, 0.225])])
+        },
+        'loader_tr_args': {
+            'batch_size': 100, 
+            'num_workers': 1
+        },
+        'loader_te_args': {
+            'batch_size': 100, 
+            'num_workers': 1
+        },
+        'loader_sample_args': {
+            'batch_size': 100, 
+            'num_workers': 1
+        },
+        'optimizer_args': {
+            'lr': 0.001,
+            'l2_regularizer_weight': 0.001,
+            'penalty_anneal_iters': 40, # make this 0 for ERM
+            'penalty_weight': 10000.0 # make this 0 for ERM
         }
     }
-       
-    args = args_pool[dataset_name]
-    model_name = args['model_path'] + "wildcam_" + str(args['steps']) + "_" + str(args['optimizer_args']['lr']) + "_" + str(args['optimizer_args']['penalty_anneal_iters']) + "_" + str(args['optimizer_args']['penalty_weight']) + "_"
+}
+
+args = args_pool[dataset_name]
+model_name = args['model_path'] + "wildcam_" + str(args['steps']) + "_" + str(args['optimizer_args']['lr']) + "_" + str(args['optimizer_args']['penalty_anneal_iters']) + "_" + str(args['optimizer_args']['penalty_weight']) + "_"
+
+np.random.seed(seed)
+torch.manual_seed(seed)
+torch.cuda.manual_seed(seed)
+torch.backends.cudnn.deterministic = True
+torch.backends.cudnn.benchmark = False
+
+
+
+# load dataset
+envs, x_test, y_test = get_dataset(dataset_name, dataset_path)
+print("working with", len(envs), "training environments: ")
+for env in envs:
+   print("env['images']: ", len(env['images']))
+   print("env['labels']: ", env['labels'].shape[0])
+
+print("x_test: ", len(x_test))
+print("y_test: ", y_test.shape[0])
+
+# get model and data handler
+net = get_net(dataset_name)
+handler = get_handler(dataset_name)
+
+# GPU enabled?
+print("Using GPU - {}".format(torch.cuda.is_available()))
+
+final_train_accs = []
+final_test_accs = []
+train_process = Train(envs, x_test, y_test, net, handler, args)
+
+
+
+start = datetime.now()
+with mlflow.start_run(nested=True):
     
-    print("\n")
+    mlflow.log_params({
+        'steps': args['steps'],
+        'lr': args['optimizer_args']['lr'],
+        'penalty_anneal_iters': args['optimizer_args']['penalty_anneal_iters'],
+        'penalty_weight': args['optimizer_args']['penalty_weight'],
+        'l2_regularizer_weight': args['optimizer_args']['l2_regularizer_weight'],
+        'train_batch_size': args['loader_tr_args']['batch_size']
+    })
+    
+    print()
     if args['optimizer_args']['penalty_weight'] > 1.0:
+        mlflow.log_param('method', 'IRM')
         model_name = model_name + "IRM.pth"
         print("========================================IRM========================================")
     else:
+        mlflow.log_param('method', 'ERM')
         model_name = model_name + "ERM.pth"
         print("========================================ERM========================================")
     print(args)
-    
-    np.random.seed(seed)
-    torch.manual_seed(seed)
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
-    
-   
-    # load dataset
-    envs, x_test, y_test = get_dataset(dataset_name, dataset_path)
-    print("working with", len(envs), "training environments: ")
-    for env in envs:
-        print("env['images']: ", len(env['images']))
-        print("env['labels']: ", env['labels'].shape[0])
-    
-    print("x_test: ", len(x_test))
-    print("y_test: ", y_test.shape[0])
 
-    # get model and data handler
-    net = get_net(dataset_name)
-    handler = get_handler(dataset_name)
-    
-    # GPU enabled?
-    print("Using GPU - {}".format(torch.cuda.is_available()))
-    
-    final_train_accs = []
-    final_test_accs = []
-    train_process = Train(envs, x_test, y_test, net, handler, args)
-    
-    start = datetime.now()
     for restart in range(args['n_restarts']):  
         print("Restart", restart)
-        train_acc, test_acc = train_process.train()
-        final_train_accs.append(train_acc)
-        final_test_accs.append(test_acc)
-            
-        print('Final train acc (mean/std across restarts so far):')
-        print(round(np.mean(final_train_accs), 4), round(np.std(final_train_accs), 4))
-        print('Final test acc (mean/std across restarts so far):')
-        print(round(np.mean(final_test_accs), 4), round(np.std(final_test_accs), 4))
     
-    end = datetime.now()
+        with mlflow.start_run(nested=True):
+            train_acc, test_acc = train_process.train()
 
-    time_elapsed = end - start
-    print("time for training: ", time_elapsed.days, time_elapsed.min, "minutes and", time_elapsed.seconds, "seconds.")
-    torch.save(train_process.clf.state_dict(), model_name)
+    final_train_accs.append(train_acc)
+    final_test_accs.append(test_acc)
+
+    mlflow.log_metrics({
+        'final_train_acc_mean': np.mean(final_train_accs),
+        'final_train_acc_std': np.std(final_train_accs),
+        'final_test_acc_mean': np.mean(final_test_accs),
+        'final_test_acc_std': np.std(final_test_accs),
+    })
+
+    print('Final train acc (mean/std across restarts so far):')
+    print(round(np.mean(final_train_accs), 4), round(np.std(final_train_accs), 4))
+    print('Final test acc (mean/std across restarts so far):')
+    print(round(np.mean(final_test_accs), 4), round(np.std(final_test_accs), 4))
+    
+    
+end = datetime.now()
+
+time_elapsed = end - start
+print("time for training: ", time_elapsed.days, time_elapsed.min, "minutes and", time_elapsed.seconds, "seconds.")
+torch.save(train_process.clf.state_dict(), model_name)

--- a/experiments/invariant-risk-minimization/wildcam/train.py
+++ b/experiments/invariant-risk-minimization/wildcam/train.py
@@ -117,9 +117,9 @@ class Train:
                 env['penalty'] = penalty / len(loader_tr)
 
                 mlflow.log_metrics({
-                    'env_'+str(env_idx)+'loss': env['nll'].item(),
-                    'env_'+str(env_idx)+'acc': env['acc'].item(),
-                    'env_'+str(env_idx)+'penalty': env['penalty'].item()
+                    'env_'+str(env_idx)+'_loss': env['nll'].item(),
+                    'env_'+str(env_idx)+'_acc': env['acc'].item(),
+                    'env_'+str(env_idx)+'_penalty': env['penalty'].item()
                 }, step=step)
                 
             train_nll = torch.stack([self.envs[0]['nll'], self.envs[1]['nll']]).mean()


### PR DESCRIPTION
This looks like a much bigger diff than it is. Most of the code has not been changed but has been moved around in chunks (which creates a large diff). The PR does a few things:
* Introduce MLflow for logging params and aggregate metrics (like mean accuracy across restarts) in `main.py`.
* Introduce individual metric logging in `train.py`
* Brings some things outside the primary loop in `main.py` that would not change between re-runs and a bit of re-arranging to accommodate MLflow more easily.

It does not do the following, which we may want to consider:
* It does not remove any of the original logging, so everything is still printed to stdout
* It does not use mlflow model logging, it sticks with `torch.save`. We can change that easily if we want, but for now I was prioritizing compatibility with the downstream code for interpretability.